### PR TITLE
Fix compilation on gcc13 by missing stdint.h

### DIFF
--- a/libgbc/instruction.hpp
+++ b/libgbc/instruction.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <stdint.h>
 
 namespace gbc
 {


### PR DESCRIPTION
Some compiler will not find the type uint8_t if stdint.h is not defined, this solves the compilation issue.